### PR TITLE
Correct instructions to turn off

### DIFF
--- a/Formula/brew-growl.rb
+++ b/Formula/brew-growl.rb
@@ -17,11 +17,11 @@ To turn on brew growl,
 
 Add the following to your ~/.zshrc or ~/.bashrc:
 
-  source ~/.brew-growl
+  source ~/.brew-growl 2> /dev/null
 
-To switch of later,
+To switch off later,
 
-  brew growl on
+  brew growl off
     EOS
   end
 end


### PR DESCRIPTION
change on to off
re-direct stderr to /dev/null to suppress an error message if there is no ~/.brew-grow to source
